### PR TITLE
Fix/memlist check year

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urburzip",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/api/registerToXls.ts
+++ b/src/api/registerToXls.ts
@@ -39,10 +39,15 @@ const applyToXlsx = async () => {
     ];
     const q1 = query(
       collection(dbService, "members"),
+      where("year", "==", year_input),
       where("semester", "==", "1"),
       orderBy("name", "asc")
     );
     const memberData1 = await getDocs(q1);
+    if (memberData1.empty) {
+      alert(`${year_input}년 명부가 존재하지 않습니다`);
+      return;
+    }
     const arr1 = memberData1.docs.map((doc) => ({
       id: doc.id,
       ...doc.data(),
@@ -54,6 +59,7 @@ const applyToXlsx = async () => {
 
     const q2 = query(
       collection(dbService, "members"),
+      where("year", "==", year_input),
       where("semester", "==", "2"),
       orderBy("name", "asc")
     );


### PR DESCRIPTION
명부 다운로드를 받을 때 년도 조건을 검사합니다.
추가로 데이터가 없으면 경고 메세지가 출력되고 파일이 다운로드 되지 않습니다.